### PR TITLE
Session persistance: clean up $_SESSION between tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - '[[ -z "$CI_USER_TOKEN" ]] || composer config github-oauth.github.com ${CI_USER_TOKEN};'
   - travis_retry composer self-update && composer --version
   - travis_retry composer update --prefer-dist --no-interaction
-  - git clone -q --depth=1 -b master --recurse-submodules https://github.com/Slamdunk/codeception-mezzio-tests framework-tests
+  - git clone -q --depth=1 -b session_test --recurse-submodules https://github.com/Slamdunk/codeception-mezzio-tests framework-tests
   - git --git-dir framework-tests/.git log -n 1
   - travis_retry composer update -d framework-tests --no-dev --prefer-dist --no-interaction
   - php ./vendor/bin/codecept build -c framework-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - '[[ -z "$CI_USER_TOKEN" ]] || composer config github-oauth.github.com ${CI_USER_TOKEN};'
   - travis_retry composer self-update && composer --version
   - travis_retry composer update --prefer-dist --no-interaction
-  - git clone -q --depth=1 -b session_test --recurse-submodules https://github.com/Slamdunk/codeception-mezzio-tests framework-tests
+  - git clone -q --depth=1 -b master --recurse-submodules https://github.com/Slamdunk/codeception-mezzio-tests framework-tests
   - git --git-dir framework-tests/.git log -n 1
   - travis_retry composer update -d framework-tests --no-dev --prefer-dist --no-interaction
   - php ./vendor/bin/codecept build -c framework-tests

--- a/src/Codeception/Module/Mezzio.php
+++ b/src/Codeception/Module/Mezzio.php
@@ -85,7 +85,7 @@ class Mezzio extends Framework implements DoctrineProvider
             session_write_close();
         }
         if (isset($_SESSION)) {
-            session_unset();
+            $_SESSION = [];
         }
 
         parent::_after($test);

--- a/src/Codeception/Module/Mezzio.php
+++ b/src/Codeception/Module/Mezzio.php
@@ -84,6 +84,9 @@ class Mezzio extends Framework implements DoctrineProvider
         if (session_status() == PHP_SESSION_ACTIVE) {
             session_write_close();
         }
+        if (isset($_SESSION)) {
+            session_unset();
+        }
 
         parent::_after($test);
     }


### PR DESCRIPTION
Related new tests: https://github.com/Slamdunk/codeception-mezzio-tests/pull/2/files