### PR TITLE
Code standards updated to PHP 7.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"minimum-stability": "RC",
 	"require": {
-		"php": "^7.1 || ^8.0",
+		"php": "^7.3 || ^8.0",
 		"codeception/lib-innerbrowser": "^1.0",
 		"codeception/codeception": "^4.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -1,29 +1,31 @@
 {
-    "name":"codeception/module-mezzio",
-    "description":"Codeception module for Mezzio framework",
-    "keywords":["codeception", "mezzio"],
-    "homepage":"http://codeception.com/",
-    "type":"library",
-    "license":"MIT",
-    "authors":[
-        {
-            "name":"Gintautas Miselis"
-        }
-    ],
-    "minimum-stability": "RC",
-    "require": {
-        "php": ">=5.6.0 <9.0",
-        "codeception/lib-innerbrowser": "^1.0",
-        "codeception/codeception": "^4.0"
-    },
-    "require-dev": {
-        "codeception/module-rest": "dev-master",
-        "mezzio/mezzio": "~2.0 | ~3.0"
-    },
-    "autoload":{
-        "classmap": ["src/"]
-    },
-    "config": {
-        "classmap-authoritative": true
-    }
+	"name": "codeception/module-mezzio",
+	"description": "Codeception module for Mezzio framework",
+	"keywords": [ "codeception", "mezzio" ],
+	"homepage": "https://codeception.com/",
+	"type": "library",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Gintautas Miselis"
+		}
+	],
+	"minimum-stability": "RC",
+	"require": {
+		"php": "^7.1 || ^8.0",
+		"codeception/lib-innerbrowser": "^1.0",
+		"codeception/codeception": "^4.0"
+	},
+	"require-dev": {
+		"codeception/module-rest": "^1.0",
+		"mezzio/mezzio": "^3.0"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"config": {
+		"classmap-authoritative": true
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ A Codeception module for Mezzio framework.
 
 ## Requirements
 
-* `PHP 7.1` or higher.
+* `PHP 7.3` or higher.
 
 ## Installation
 

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,10 @@ A Codeception module for Mezzio framework.
 [![Total Downloads](https://poser.pugx.org/codeception/module-mezzio/downloads)](https://packagist.org/packages/codeception/module-mezzio)
 [![License](https://poser.pugx.org/codeception/module-mezzio/license)](/LICENSE)
 
+## Requirements
+
+* `PHP 7.1` or higher.
+
 ## Installation
 
 ```

--- a/src/Codeception/Lib/Connector/Mezzio.php
+++ b/src/Codeception/Lib/Connector/Mezzio.php
@@ -41,7 +41,7 @@ class Mezzio extends Client
      * @param BrowserKitRequest $request
      * @throws Exception
      */
-    public function doRequest($request): Response
+    public function doRequest($request)
     {
         $inputStream = fopen('php://memory', 'r+');
         $content = $request->getContent();
@@ -158,7 +158,7 @@ class Mezzio extends Client
         return $headers;
     }
 
-    public function initApplication()
+    public function initApplication(): Application
     {
         $cwd = getcwd();
         $projectDir = Configuration::projectDir();
@@ -218,7 +218,7 @@ class Mezzio extends Client
         return $this->container;
     }
 
-    public function setApplication(Application $application)
+    public function setApplication(Application $application): void
     {
         $this->application = $application;
         $this->initResponseCollector();

--- a/src/Codeception/Lib/Connector/Mezzio.php
+++ b/src/Codeception/Lib/Connector/Mezzio.php
@@ -1,8 +1,13 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Connector;
 
 use Codeception\Configuration;
 use Codeception\Lib\Connector\Mezzio\ResponseCollector;
+use Exception;
+use Interop\Container\ContainerInterface;
 use Symfony\Component\BrowserKit\AbstractBrowser as Client;
 use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\BrowserKit\Request as BrowserKitRequest;
@@ -23,7 +28,7 @@ class Mezzio extends Client
     private $responseCollector;
 
     /**
-     * @var \Interop\Container\ContainerInterface
+     * @var ContainerInterface
      */
     private $container;
 
@@ -34,11 +39,9 @@ class Mezzio extends Client
 
     /**
      * @param BrowserKitRequest $request
-     *
-     * @return Response
-     * @throws \Exception
+     * @throws Exception
      */
-    public function doRequest($request)
+    public function doRequest($request): Response
     {
         $inputStream = fopen('php://memory', 'r+');
         $content = $request->getContent();
@@ -115,7 +118,7 @@ class Mezzio extends Client
         );
     }
 
-    private function convertFiles(array $files)
+    private function convertFiles(array $files): array
     {
         $fileObjects = [];
         foreach ($files as $fieldName => $file) {
@@ -136,7 +139,7 @@ class Mezzio extends Client
         return $fileObjects;
     }
 
-    private function extractHeaders(BrowserKitRequest $request)
+    private function extractHeaders(BrowserKitRequest $request): array
     {
         $headers = [];
         $server = $request->getServer();
@@ -191,7 +194,7 @@ class Mezzio extends Client
         return $app;
     }
 
-    private function initResponseCollector()
+    private function initResponseCollector(): void
     {
         if (!method_exists($this->application, 'getEmitter')) {
             //Does not exist in Mezzio v3
@@ -210,21 +213,18 @@ class Mezzio extends Client
         $emitterStack->unshift($this->responseCollector);
     }
 
-    public function getContainer()
+    public function getContainer(): ContainerInterface
     {
         return $this->container;
     }
 
-    /**
-     * @param Application
-     */
     public function setApplication(Application $application)
     {
         $this->application = $application;
         $this->initResponseCollector();
     }
 
-    public function setConfig(array $config)
+    public function setConfig(array $config): void
     {
         $this->config = $config;
     }

--- a/src/Codeception/Lib/Connector/Mezzio/ResponseCollector.php
+++ b/src/Codeception/Lib/Connector/Mezzio/ResponseCollector.php
@@ -1,6 +1,10 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Connector\Mezzio;
 
+use LogicException;
 use Psr\Http\Message\ResponseInterface;
 use Laminas\Diactoros\Response\EmitterInterface;
 
@@ -16,15 +20,15 @@ class ResponseCollector implements EmitterInterface
         $this->response = $response;
     }
 
-    public function getResponse()
+    public function getResponse(): ResponseInterface
     {
         if ($this->response === null) {
-            throw new \LogicException('Response wasn\'t emitted yet');
+            throw new LogicException('Response wasn\'t emitted yet');
         }
         return $this->response;
     }
 
-    public function clearResponse()
+    public function clearResponse(): void
     {
         $this->response = null;
     }

--- a/src/Codeception/Module/Mezzio.php
+++ b/src/Codeception/Module/Mezzio.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Module;
 
 use Codeception\Lib\Framework;
@@ -31,6 +34,9 @@ use Codeception\Lib\Interfaces\DoctrineProvider;
  */
 class Mezzio extends Framework implements DoctrineProvider
 {
+    /**
+     * @var array
+     */
     protected $config = [
         'container'                          => 'config/container.php',
         'recreateApplicationBetweenTests'    => true,
@@ -73,7 +79,7 @@ class Mezzio extends Framework implements DoctrineProvider
         if ($this->config['recreateApplicationBetweenTests'] != false && $this->config['recreateApplicationBetweenRequests'] == false) {
             $this->application = $this->client->initApplication();
             $this->container   = $this->client->getContainer();
-        } elseif (isset($this->application)) {
+        } elseif ($this->application !== null) {
             $this->client->setApplication($this->application);
         }
     }


### PR DESCRIPTION
- The minimum version of PHP is now 7.3
- Added strict types
- Added return types
- Removed unnecessary qualifiers
- Removed support for Mezzio 2