### PR TITLE
Migrate from container-interop to psr/container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         submodules: recursive
 
     - name: Install Mezzio Sample
-      run: composer update --no-dev --prefer-dist --no-interaction
+      run: composer update --prefer-dist --no-interaction
       working-directory: framework-tests
 
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"php": "^8.0",
 		"codeception/lib-innerbrowser": "^3.0 | ^4.0",
 		"codeception/codeception": "^5.0.8",
-		"container-interop/container-interop": "^1.2",
+		"psr/container": "^1 | ^2",
 		"laminas/laminas-diactoros": "^2.0 || ^3.0",
 		"mezzio/mezzio": "^3.0"
 	},

--- a/src/Codeception/Lib/Connector/Mezzio.php
+++ b/src/Codeception/Lib/Connector/Mezzio.php
@@ -6,7 +6,7 @@ namespace Codeception\Lib\Connector;
 
 use Codeception\Configuration;
 use Exception;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\UploadedFile;
 use Mezzio\Application;

--- a/src/Codeception/Module/Mezzio.php
+++ b/src/Codeception/Module/Mezzio.php
@@ -9,7 +9,7 @@ use Codeception\Lib\Framework;
 use Codeception\Lib\Interfaces\DoctrineProvider;
 use Codeception\TestInterface;
 use Doctrine\ORM\EntityManagerInterface;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Mezzio\Application;
 use PHPUnit\Framework\AssertionFailedError;
 use Symfony\Component\BrowserKit\AbstractBrowser;
@@ -33,7 +33,7 @@ use Symfony\Component\BrowserKit\AbstractBrowser;
  * ## Public properties
  *
  * * application -  instance of `\Mezzio\Application`
- * * container - instance of `\Interop\Container\ContainerInterface`
+ * * container - instance of `\Psr\Container\ContainerInterface`
  * * client - BrowserKit client
  *
  */


### PR DESCRIPTION
## Summary

The `container-interop/container-interop` package is [abandoned](https://github.com/container-interop/container-interop#readme) and pinned to `psr/container ^1.0`, which prevents projects from using `psr/container ^2.0`.

This PR replaces the deprecated dependency with `psr/container ^1|^2` and updates all `use` statements from `Interop\Container\ContainerInterface` to the standard `Psr\Container\ContainerInterface`.

### Changes

- **composer.json**: Replace `container-interop/container-interop: ^1.2` with `psr/container: ^1 | ^2`
- **src/Codeception/Module/Mezzio.php**: Update `use` statement and docblock reference
- **src/Codeception/Lib/Connector/Mezzio.php**: Update `use` statement

This is a backwards-compatible change since `Interop\Container\ContainerInterface` was just an alias for `Psr\Container\ContainerInterface`.

Fixes #19. Supersedes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)